### PR TITLE
Add support for SLF4J 2.0's new fluent API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <gwt.version>2.8.2</gwt.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/slf4gwt-gwtlog/pom.xml
+++ b/slf4gwt-gwtlog/pom.xml
@@ -3,7 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>slf4gwt-gwtlog</artifactId>
-  <version>1.5-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <packaging>jar</packaging>
 

--- a/slf4gwt/pom.xml
+++ b/slf4gwt/pom.xml
@@ -3,7 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>slf4gwt</artifactId>
-  <version>1.5-SNAPSHOT</version>
   <name>${project.artifactId}</name>
   <packaging>jar</packaging>
 

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/ILoggerFactory.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/ILoggerFactory.java
@@ -29,7 +29,7 @@ package org.slf4j;
  * instances by name.
  *
  * <p>Most users retrieve {@link Logger} instances through the static
- * {@link LoggerFactory#getLogger(String)} method. An instance of of this
+ * {@link LoggerFactory#getLogger(String)} method. An instance of this
  * interface is bound internally with {@link LoggerFactory} class at
  * compile time.
  *

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/Logger.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/Logger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2004-2011 QOS.ch
+ * Copyright (c) 2004-2022 QOS.ch
  * All rights reserved.
  *
  * Permission is hereby granted, free  of charge, to any person obtaining
@@ -22,14 +22,32 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  */
+
 package org.slf4j;
+
+import static org.slf4j.event.EventConstants.DEBUG_INT;
+import static org.slf4j.event.EventConstants.ERROR_INT;
+import static org.slf4j.event.EventConstants.INFO_INT;
+import static org.slf4j.event.EventConstants.TRACE_INT;
+import static org.slf4j.event.EventConstants.WARN_INT;
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.ERROR;
+import static org.slf4j.event.Level.INFO;
+import static org.slf4j.event.Level.TRACE;
+import static org.slf4j.event.Level.WARN;
+
+import org.slf4j.event.Level;
+import org.slf4j.helpers.CheckReturnValue;
+import org.slf4j.spi.DefaultLoggingEventBuilder;
+import org.slf4j.spi.LoggingEventBuilder;
+import org.slf4j.spi.NOPLoggingEventBuilder;
 
 /**
  * The org.slf4j.Logger interface is the main user entry point of SLF4J API.
  * It is expected that logging takes place through concrete implementations
  * of this interface.
- * <p/>
- * <h3>Typical usage pattern:</h3>
+ * 
+ * <H3>Typical usage pattern:</H3>
  * <pre>
  * import org.slf4j.Logger;
  * import org.slf4j.LoggerFactory;
@@ -44,26 +62,29 @@ package org.slf4j;
  *     oldT = t;
  *     t = temperature;
  *     <span style="color:green">logger.debug("Temperature set to {}. Old temperature was {}.", t, oldT);</span>
- *     if(temperature.intValue() > 50) {
+ *     if (temperature.intValue() &gt; 50) {
  *       <span style="color:green">logger.info("Temperature has risen above 50 degrees.");</span>
  *     }
  *   }
  * }
  * </pre>
  *
- * Be sure to read the FAQ entry relating to <a href="../../../faq.html#logging_performance">parameterized
+ * <p>Note that version 2.0 of the SLF4J API introduces a <a href="../../../manual.html#fluent">fluent api</a>,
+ * the most significant API change to occur in the last 20 years.
+ *
+ * <p>Be sure to read the FAQ entry relating to <a href="../../../faq.html#logging_performance">parameterized
  * logging</a>. Note that logging statements can be parameterized in
  * <a href="../../../faq.html#paramException">presence of an exception/throwable</a>.
  *
  * <p>Once you are comfortable using loggers, i.e. instances of this interface, consider using
- * <a href="MDC.html">MDC</a> as well as <a href="Marker.html">Markers</a>.</p>
+ * <a href="MDC.html">MDC</a> as well as <a href="Marker.html">Markers</a>.
  *
  * @author Ceki G&uuml;lc&uuml;
  */
 public interface Logger {
 
   /**
-   * Case insensitive String constant used to retrieve the name of the root logger.
+   * Case-insensitive String constant used to retrieve the name of the root logger.
    *
    * @since 1.3
    */
@@ -71,9 +92,73 @@ public interface Logger {
 
   /**
    * Return the name of this <code>Logger</code> instance.
-   * @return name of this logger instance
+   * @return name of this logger instance 
    */
   public String getName();
+
+  /**
+   * <p>Make a new {@link LoggingEventBuilder} instance as appropriate for this logger implementation.
+   * This default implementation always returns a new instance of {@link DefaultLoggingEventBuilder}.</p>
+   * <p></p>
+   * <p>This method is intended to be used by logging systems implementing the SLF4J API and <b>not</b>
+   * by end users.</p>
+   * <p></p>
+   * <p>Also note that a {@link LoggingEventBuilder} instance should be built for all levels,
+   * independently of the level argument. In other words, this method is an <b>unconditional</b>
+   * constructor for the {@link LoggingEventBuilder} appropriate for this logger implementation.</p>
+   * <p></p>
+   * @param level desired level for the event builder
+   * @return a new {@link LoggingEventBuilder} instance as appropriate for <b>this</b> logger
+   * @since 2.0
+   */
+  default public LoggingEventBuilder makeLoggingEventBuilder(Level level) {
+    return new DefaultLoggingEventBuilder(this, level);
+  }
+
+  /**
+   * Make a new {@link LoggingEventBuilder} instance as appropriate for this logger and the
+   * desired {@link Level} passed as parameter. If this Logger is disabled for the given Level, then
+   * a {@link  NOPLoggingEventBuilder} is returned.
+   *
+   *
+   * @param level desired level for the event builder
+   * @return a new {@link LoggingEventBuilder} instance as appropriate for this logger
+   * @since 2.0
+   */
+  @CheckReturnValue
+  default public LoggingEventBuilder atLevel(Level level) {
+    if (isEnabledForLevel(level)) {
+      return makeLoggingEventBuilder(level);
+    } else {
+      return NOPLoggingEventBuilder.singleton();
+    }
+  }
+
+  
+  
+  /**
+   * Returns whether this Logger is enabled for a given {@link Level}. 
+   * 
+   * @param level
+   * @return true if enabled, false otherwise.
+   */
+  default public boolean isEnabledForLevel(Level level) {
+    int levelInt = level.toInt();
+    switch (levelInt) {
+    case (TRACE_INT):
+      return isTraceEnabled();
+    case (DEBUG_INT):
+      return isDebugEnabled();
+    case (INFO_INT):
+      return isInfoEnabled();
+    case (WARN_INT):
+      return isWarnEnabled();
+    case (ERROR_INT):
+      return isErrorEnabled();
+    default:
+      throw new IllegalArgumentException("Level [" + level + "] not recognized.");
+    }
+  }
 
   /**
    * Is the logger instance enabled for the TRACE level?
@@ -95,9 +180,9 @@ public interface Logger {
   /**
    * Log a message at the TRACE level according to the specified format
    * and argument.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the TRACE level. </p>
+   * is disabled for the TRACE level. 
    *
    * @param format the format string
    * @param arg    the argument
@@ -108,9 +193,9 @@ public interface Logger {
   /**
    * Log a message at the TRACE level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the TRACE level. </p>
+   * is disabled for the TRACE level. 
    *
    * @param format the format string
    * @param arg1   the first argument
@@ -122,12 +207,12 @@ public interface Logger {
   /**
    * Log a message at the TRACE level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous string concatenation when the logger
    * is disabled for the TRACE level. However, this variant incurs the hidden
    * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
    * even if this logger is disabled for TRACE. The variants taking {@link #trace(String, Object) one} and
-   * {@link #trace(String, Object, Object) two} arguments exist solely in order to avoid this hidden cost.</p>
+   * {@link #trace(String, Object, Object) two} arguments exist solely in order to avoid this hidden cost.
    *
    * @param format    the format string
    * @param arguments a list of 3 or more arguments
@@ -152,10 +237,25 @@ public interface Logger {
    * @param marker The marker data to take into consideration
    * @return True if this Logger is enabled for the TRACE level,
    *         false otherwise.
-   *
+   *         
    * @since 1.4
    */
   public boolean isTraceEnabled(Marker marker);
+
+  /**
+   * Entry point for fluent-logging for {@link org.slf4j.event.Level#TRACE} level. 
+   *  
+   * @return LoggingEventBuilder instance as appropriate for level TRACE
+   * @since 2.0
+   */
+  @CheckReturnValue
+  default public LoggingEventBuilder atTrace() {
+      if (isTraceEnabled()) {
+          return makeLoggingEventBuilder(TRACE);
+      } else {
+          return NOPLoggingEventBuilder.singleton();
+      }
+  }
 
   /**
    * Log a message with the specific Marker at the TRACE level.
@@ -231,9 +331,9 @@ public interface Logger {
   /**
    * Log a message at the DEBUG level according to the specified format
    * and argument.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the DEBUG level. </p>
+   * is disabled for the DEBUG level. 
    *
    * @param format the format string
    * @param arg    the argument
@@ -243,9 +343,9 @@ public interface Logger {
   /**
    * Log a message at the DEBUG level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the DEBUG level. </p>
+   * is disabled for the DEBUG level. 
    *
    * @param format the format string
    * @param arg1   the first argument
@@ -256,13 +356,13 @@ public interface Logger {
   /**
    * Log a message at the DEBUG level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous string concatenation when the logger
    * is disabled for the DEBUG level. However, this variant incurs the hidden
    * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
    * even if this logger is disabled for DEBUG. The variants taking
    * {@link #debug(String, Object) one} and {@link #debug(String, Object, Object) two}
-   * arguments exist solely in order to avoid this hidden cost.</p>
+   * arguments exist solely in order to avoid this hidden cost.
    *
    * @param format    the format string
    * @param arguments a list of 3 or more arguments
@@ -284,7 +384,7 @@ public interface Logger {
    *
    * @param marker The marker data to take into consideration
    * @return True if this Logger is enabled for the DEBUG level,
-   *         false otherwise.
+   *         false otherwise. 
    */
   public boolean isDebugEnabled(Marker marker);
 
@@ -340,6 +440,21 @@ public interface Logger {
   public void debug(Marker marker, String msg, Throwable t);
 
   /**
+   * Entry point for fluent-logging for {@link org.slf4j.event.Level#DEBUG} level. 
+   *  
+   * @return LoggingEventBuilder instance as appropriate for level DEBUG
+   * @since 2.0
+   */
+  @CheckReturnValue
+  default public LoggingEventBuilder atDebug() {
+      if (isDebugEnabled()) {
+          return makeLoggingEventBuilder(DEBUG);
+      } else {
+          return NOPLoggingEventBuilder.singleton();
+      }
+  }
+
+  /**
    * Is the logger instance enabled for the INFO level?
    *
    * @return True if this Logger is enabled for the INFO level,
@@ -357,9 +472,9 @@ public interface Logger {
   /**
    * Log a message at the INFO level according to the specified format
    * and argument.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the INFO level. </p>
+   * is disabled for the INFO level. 
    *
    * @param format the format string
    * @param arg    the argument
@@ -369,9 +484,9 @@ public interface Logger {
   /**
    * Log a message at the INFO level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the INFO level. </p>
+   * is disabled for the INFO level. 
    *
    * @param format the format string
    * @param arg1   the first argument
@@ -382,13 +497,13 @@ public interface Logger {
   /**
    * Log a message at the INFO level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous string concatenation when the logger
    * is disabled for the INFO level. However, this variant incurs the hidden
    * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
    * even if this logger is disabled for INFO. The variants taking
    * {@link #info(String, Object) one} and {@link #info(String, Object, Object) two}
-   * arguments exist solely in order to avoid this hidden cost.</p>
+   * arguments exist solely in order to avoid this hidden cost.
    *
    * @param format    the format string
    * @param arguments a list of 3 or more arguments
@@ -409,7 +524,8 @@ public interface Logger {
    * data is also taken into consideration.
    *
    * @param marker The marker data to take into consideration
-   * @return true if this logger is warn enabled, false otherwise
+   * @return true if this Logger is enabled for the INFO level,
+   *         false otherwise.
    */
   public boolean isInfoEnabled(Marker marker);
 
@@ -465,6 +581,21 @@ public interface Logger {
   public void info(Marker marker, String msg, Throwable t);
 
   /**
+   * Entry point for fluent-logging for {@link org.slf4j.event.Level#INFO} level. 
+   *  
+   * @return LoggingEventBuilder instance as appropriate for level INFO
+   * @since 2.0
+   */
+  @CheckReturnValue
+  default public LoggingEventBuilder atInfo() {
+      if (isInfoEnabled()) {
+          return makeLoggingEventBuilder(INFO);
+      } else {
+          return NOPLoggingEventBuilder.singleton();
+      }
+  }
+
+  /**
    * Is the logger instance enabled for the WARN level?
    *
    * @return True if this Logger is enabled for the WARN level,
@@ -482,9 +613,9 @@ public interface Logger {
   /**
    * Log a message at the WARN level according to the specified format
    * and argument.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the WARN level. </p>
+   * is disabled for the WARN level. 
    *
    * @param format the format string
    * @param arg    the argument
@@ -494,13 +625,13 @@ public interface Logger {
   /**
    * Log a message at the WARN level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous string concatenation when the logger
    * is disabled for the WARN level. However, this variant incurs the hidden
    * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
    * even if this logger is disabled for WARN. The variants taking
    * {@link #warn(String, Object) one} and {@link #warn(String, Object, Object) two}
-   * arguments exist solely in order to avoid this hidden cost.</p>
+   * arguments exist solely in order to avoid this hidden cost.
    *
    * @param format    the format string
    * @param arguments a list of 3 or more arguments
@@ -510,9 +641,9 @@ public interface Logger {
   /**
    * Log a message at the WARN level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the WARN level. </p>
+   * is disabled for the WARN level. 
    *
    * @param format the format string
    * @param arg1   the first argument
@@ -591,6 +722,21 @@ public interface Logger {
   public void warn(Marker marker, String msg, Throwable t);
 
   /**
+   * Entry point for fluent-logging for {@link org.slf4j.event.Level#WARN} level. 
+   *  
+   * @return LoggingEventBuilder instance as appropriate for level WARN
+   * @since 2.0
+   */
+  @CheckReturnValue
+  default public LoggingEventBuilder atWarn() {
+      if (isWarnEnabled()) {
+          return makeLoggingEventBuilder(WARN);
+      } else {
+          return NOPLoggingEventBuilder.singleton();
+      }
+  }
+
+  /**
    * Is the logger instance enabled for the ERROR level?
    *
    * @return True if this Logger is enabled for the ERROR level,
@@ -608,9 +754,9 @@ public interface Logger {
   /**
    * Log a message at the ERROR level according to the specified format
    * and argument.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the ERROR level. </p>
+   * is disabled for the ERROR level. 
    *
    * @param format the format string
    * @param arg    the argument
@@ -620,9 +766,9 @@ public interface Logger {
   /**
    * Log a message at the ERROR level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous object creation when the logger
-   * is disabled for the ERROR level. </p>
+   * is disabled for the ERROR level. 
    *
    * @param format the format string
    * @param arg1   the first argument
@@ -633,13 +779,13 @@ public interface Logger {
   /**
    * Log a message at the ERROR level according to the specified format
    * and arguments.
-   * <p/>
+   * 
    * <p>This form avoids superfluous string concatenation when the logger
    * is disabled for the ERROR level. However, this variant incurs the hidden
    * (and relatively small) cost of creating an <code>Object[]</code> before invoking the method,
    * even if this logger is disabled for ERROR. The variants taking
    * {@link #error(String, Object) one} and {@link #error(String, Object, Object) two}
-   * arguments exist solely in order to avoid this hidden cost.</p>
+   * arguments exist solely in order to avoid this hidden cost.
    *
    * @param format    the format string
    * @param arguments a list of 3 or more arguments
@@ -716,5 +862,20 @@ public interface Logger {
    * @param t      the exception (throwable) to log
    */
   public void error(Marker marker, String msg, Throwable t);
+
+  /**
+   * Entry point for fluent-logging for {@link org.slf4j.event.Level#ERROR} level. 
+   *  
+   * @return LoggingEventBuilder instance as appropriate for level ERROR
+   * @since 2.0
+   */
+  @CheckReturnValue
+  default public LoggingEventBuilder atError() {
+      if (isErrorEnabled()) {
+          return makeLoggingEventBuilder(ERROR);
+      } else {
+          return NOPLoggingEventBuilder.singleton();
+      }
+  }
 
 }

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/LoggerFactory.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/LoggerFactory.java
@@ -28,20 +28,20 @@ import org.slf4gwt.logging.impl.Impl;
 
 /**
  * The <code>LoggerFactory</code> is a utility class producing Loggers for
- * various logging APIs, most notably for log4j, logback and JDK 1.4 logging.
- * Other implementations such as {@link org.slf4j.impl.NOPLogger NOPLogger} and
- * {@link org.slf4j.impl.SimpleLogger SimpleLogger} are also supported.
- * <p/>
- * <p/>
- * <code>LoggerFactory</code> is essentially a wrapper around an
- * {@link ILoggerFactory} instance bound with <code>LoggerFactory</code> at
- * compile time.
- * <p/>
- * <p/>
+ * various logging APIs, e.g. logback, reload4j, log4j and JDK 1.4 logging.
+ * Other implementations such as {@link org.slf4j.helpers.NOPLogger NOPLogger} and
+ * SimpleLogger are also supported.
+ *
+ * <p><code>LoggerFactory</code>  is essentially a wrapper around an
+ * {@link ILoggerFactory} instance provided by a {@link SLF4JServiceProvider}.
+ *
+ * <p>
  * Please note that all methods in <code>LoggerFactory</code> are static.
  *
- * @author Ceki G&uuml;lc&uuml;
+ * @author Alexander Dorokhine
  * @author Robert Elliot
+ * @author Ceki G&uuml;lc&uuml;
+ *
  */
 public class LoggerFactory {
   private LoggerFactory() {

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/Marker.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/Marker.java
@@ -29,13 +29,15 @@ import java.util.Iterator;
 
 /**
  * Markers are named objects used to enrich log statements. Conforming logging
- * system Implementations of SLF4J determine how information conveyed by markers
- * are used, if at all. In particular, many conforming logging systems ignore
- * marker data.
+ * system implementations of SLF4J should determine how information conveyed by
+ * any markers are used, if at all. Many conforming logging systems ignore marker
+ * data entirely.
  *
- * <p>
- * Markers can contain references to other markers, which in turn may contain
- * references of their own.
+ * <p>Markers can contain references to nested markers, which in turn may
+ * contain references of their own. Note that the fluent API (new in 2.0) allows adding
+ * multiple markers to a logging statement. It is often preferable to use
+ * multiple markers instead of nested markers.
+ * </p>
  *
  * @author Ceki G&uuml;lc&uuml;
  */
@@ -61,6 +63,10 @@ public interface Marker extends Serializable {
   /**
    * Add a reference to another Marker.
    *
+   * <p>Note that the fluent API allows adding multiple markers to a logging statement.
+   * It is often preferable to use multiple markers instead of nested markers.
+   * </p>
+   *
    * @param reference
    *                a reference to another marker
    * @throws IllegalArgumentException
@@ -80,6 +86,7 @@ public interface Marker extends Serializable {
   /**
    * @deprecated Replaced by {@link #hasReferences()}.
    */
+  @Deprecated
   public boolean hasChildren();
 
   /**

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/DefaultLoggingEvent.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/DefaultLoggingEvent.java
@@ -1,0 +1,140 @@
+package org.slf4j.event;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ * A default implementation of {@link LoggingEvent}.
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ *
+ * @since 2.0.0
+ */
+public class DefaultLoggingEvent implements LoggingEvent {
+
+  Logger logger;
+  Level level;
+
+  String message;
+  List<Marker> markers;
+  List<Object> arguments;
+  List<KeyValuePair> keyValuePairs;
+
+  Throwable throwable;
+  String threadName;
+  long timeStamp;
+  
+  String callerBoundary;
+
+  public DefaultLoggingEvent(Level level, Logger logger) {
+    this.logger = logger;
+    this.level = level;
+  }
+
+  public void addMarker(Marker marker) {
+    if (markers == null) {
+      markers = new ArrayList<>(2);
+    }
+    markers.add(marker);
+  }
+
+  @Override
+  public List<Marker> getMarkers() {
+    return markers;
+  }
+
+  public void addArgument(Object p) {
+    getNonNullArguments().add(p);
+  }
+
+  public void addArguments(Object... args) {
+    getNonNullArguments().addAll(Arrays.asList(args));
+  }
+
+  private List<Object> getNonNullArguments() {
+    if (arguments == null) {
+      arguments = new ArrayList<>(3);
+    }
+    return arguments;
+  }
+
+  @Override
+  public List<Object> getArguments() {
+    return arguments;
+  }
+
+  @Override
+  public Object[] getArgumentArray() {
+    if (arguments == null)
+      return null;
+    return arguments.toArray();
+  }
+
+  public void addKeyValue(String key, Object value) {
+    getNonnullKeyValuePairs().add(new KeyValuePair(key, value));
+  }
+
+  private List<KeyValuePair> getNonnullKeyValuePairs() {
+    if (keyValuePairs == null) {
+      keyValuePairs = new ArrayList<>(4);
+    }
+    return keyValuePairs;
+  }
+
+  @Override
+  public List<KeyValuePair> getKeyValuePairs() {
+    return keyValuePairs;
+  }
+
+  public void setThrowable(Throwable cause) {
+    this.throwable = cause;
+  }
+
+  @Override
+  public Level getLevel() {
+    return level;
+  }
+
+  @Override
+  public String getLoggerName() {
+    return logger.getName();
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  @Override
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  public String getThreadName() {
+    return threadName;
+  }
+
+  public long getTimeStamp() {
+    return timeStamp;
+  }
+
+  public void setTimeStamp(long timeStamp) {
+    this.timeStamp = timeStamp;
+  }
+
+  public void setCallerBoundary(String fqcn) {
+    this.callerBoundary = fqcn;
+  }
+
+  public String getCallerBoundary() {
+    return callerBoundary;
+  }
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/KeyValuePair.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/KeyValuePair.java
@@ -1,0 +1,34 @@
+package org.slf4j.event;
+
+import java.util.Objects;
+
+public class KeyValuePair {
+
+  public final String key;
+  public final Object value;
+
+  public KeyValuePair(String key, Object value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(key) + "=\"" + String.valueOf(value) + "\"";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    KeyValuePair that = (KeyValuePair) o;
+    return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value);
+  }
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/Level.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/Level.java
@@ -1,0 +1,56 @@
+package org.slf4j.event;
+
+import static org.slf4j.event.EventConstants.DEBUG_INT;
+import static org.slf4j.event.EventConstants.ERROR_INT;
+import static org.slf4j.event.EventConstants.INFO_INT;
+import static org.slf4j.event.EventConstants.TRACE_INT;
+import static org.slf4j.event.EventConstants.WARN_INT;
+
+/**
+ * SLF4J's internal representation of Level.
+ * 
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ * @since 1.7.15
+ */
+public enum Level {
+
+  ERROR(ERROR_INT, "ERROR"), WARN(WARN_INT, "WARN"), INFO(INFO_INT, "INFO"), DEBUG(DEBUG_INT, "DEBUG"), TRACE(TRACE_INT, "TRACE");
+
+  private final int levelInt;
+  private final String levelStr;
+
+  Level(int i, String s) {
+    levelInt = i;
+    levelStr = s;
+  }
+
+  public int toInt() {
+    return levelInt;
+  }
+
+  public static Level intToLevel(int levelInt) {
+    switch (levelInt) {
+    case (TRACE_INT):
+      return TRACE;
+    case (DEBUG_INT):
+      return DEBUG;
+    case (INFO_INT):
+      return INFO;
+    case (WARN_INT):
+      return WARN;
+    case (ERROR_INT):
+      return ERROR;
+    default:
+      throw new IllegalArgumentException("Level integer [" + levelInt + "] not recognized.");
+    }
+  }
+
+  /**
+   * Returns the string representation of this Level.
+   */
+  public String toString() {
+    return levelStr;
+  }
+
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/LoggingEvent.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/event/LoggingEvent.java
@@ -1,0 +1,49 @@
+package org.slf4j.event;
+
+import java.util.List;
+
+import org.slf4j.Marker;
+
+/**
+ * The minimal interface sufficient for the restitution of data passed
+ * by the user to the SLF4J API.
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ * @since 1.7.15
+ */
+public interface LoggingEvent {
+
+  Level getLevel();
+
+  String getLoggerName();
+
+  String getMessage();
+
+  List<Object> getArguments();
+
+  Object[] getArgumentArray();
+
+  /**
+   * List of markers in the event, might be null.
+   * @return markers in the event, might be null.
+   */
+    List<Marker> getMarkers();
+
+    List<KeyValuePair> getKeyValuePairs();
+
+    Throwable getThrowable();
+
+    long getTimeStamp();
+
+    String getThreadName();
+ 
+    /**
+   * Returns the presumed caller boundary provided by the logging library (not the user of the library). 
+   * Null by default.
+   *  
+   * @return presumed caller, null by default.
+   */
+  default String getCallerBoundary() {
+      return null;
+  }
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/CheckReturnValue.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/CheckReturnValue.java
@@ -1,0 +1,30 @@
+package org.slf4j.helpers;
+
+
+import org.slf4j.Marker;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>Used to annotate methods in the {@link org.slf4j.spi.LoggingEventBuilder} interface
+ * which return an instance of LoggingEventBuilder (usually as <code>this</code>). Such
+ * methods should be followed by one of the terminating <code>log()</code> methods returning
+ * <code>void</code>.</p>
+ * <p></p>
+ * <p>IntelliJ IDEA supports a check for annotations named as <code>CheckReturnValue</code>
+ * regardless of the containing package. For more information on this feature in IntelliJ IDEA,
+ * select File &#8594; Setting &#8594; Editor &#8594; Inspections and then Java &#8594; Probable Bugs &#8594;
+ * Result of method call ignored. </p>
+ * <p></p>
+ *
+ * <p>As for Eclipse, this feature has been requested in
+ * <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=572496">bug 572496</a></p>
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @since 2.0.0-beta1
+ */
+@Documented
+@Target( { ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckReturnValue {
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/FormattingTuple.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/FormattingTuple.java
@@ -33,9 +33,9 @@ public class FormattingTuple {
 
   static public FormattingTuple NULL = new FormattingTuple(null);
 
-  private String message;
-  private Throwable throwable;
-  private Object[] argArray;
+  private final String message;
+  private final Throwable throwable;
+  private final Object[] argArray;
 
   public FormattingTuple(String message) {
     this(message, null, null);

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/MarkerIgnoringBase.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/MarkerIgnoringBase.java
@@ -34,6 +34,7 @@ import org.slf4j.Marker;
  * any marker data passed as argument.
  *
  * @author Ceki Gulcu
+ * @deprecated
  */
 public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logger {
 

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/MessageFormatter.java
@@ -83,7 +83,7 @@ import java.util.Map;
  * will return the string "File name is C:\file.zip".
  *
  * <p>
- * The formatting conventions are different than those of {@link MessageFormat}
+ * The formatting conventions are different from those of {@link MessageFormat}
  * which ships with the Java platform. This is justified by the fact that
  * SLF4J's implementation is 10 times faster than that of {@link MessageFormat}.
  * This local performance difference is both measurable and significant in the
@@ -153,7 +153,6 @@ final public class MessageFormatter {
     return arrayFormat(messagePattern, new Object[] { arg1, arg2 });
   }
 
-
   final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray) {
     Throwable throwableCandidate = MessageFormatter.getThrowableCandidate(argArray);
     Object[] args = argArray;
@@ -161,6 +160,21 @@ final public class MessageFormatter {
       args = MessageFormatter.trimmedCopy(argArray);
     }
     return arrayFormat(messagePattern, args, throwableCandidate);
+  }
+
+  /**
+   * Assumes that argArray only contains arguments with no throwable as last element.
+   * 
+   * @param messagePattern
+   * @param argArray
+   */
+  final public static String basicArrayFormat(final String messagePattern, final Object[] argArray) {
+    FormattingTuple ft = arrayFormat(messagePattern, argArray, null);
+    return ft.getMessage();
+  }
+
+  public static String basicArrayFormat(NormalizedParameters np) {
+    return basicArrayFormat(np.getMessage(), np.getArguments());
   }
 
   final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray, Throwable throwable) {
@@ -204,13 +218,13 @@ final public class MessageFormatter {
             // itself escaped: "abc x:\\{}"
             // we have to consume one backward slash
             sbuf.append(messagePattern, i, j - 1);
-            deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
+            deeplyAppendParameter(sbuf, argArray[L], new HashMap<>());
             i = j + 2;
           }
         } else {
           // normal case
           sbuf.append(messagePattern, i, j);
-          deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
+          deeplyAppendParameter(sbuf, argArray[L], new HashMap<>());
           i = j + 2;
         }
       }
@@ -402,16 +416,7 @@ final public class MessageFormatter {
    *          otherwise it returns null
    */
   public static Throwable getThrowableCandidate(final Object[] argArray) {
-    if (argArray == null || argArray.length == 0) {
-      return null;
-    }
-
-    final Object lastEntry = argArray[argArray.length - 1];
-    if (lastEntry instanceof Throwable) {
-      return (Throwable) lastEntry;
-    }
-
-    return null;
+    return NormalizedParameters.getThrowableCandidate(argArray);
   }
 
   /**
@@ -423,19 +428,7 @@ final public class MessageFormatter {
    * @return a copy of the array without the last element
    */
   public static Object[] trimmedCopy(final Object[] argArray) {
-    if (argArray == null || argArray.length == 0) {
-      throw new IllegalStateException("non-sensical empty or null argument array");
-    }
-
-    final int trimmedLen = argArray.length - 1;
-
-    Object[] trimmed = new Object[trimmedLen];
-
-    if (trimmedLen > 0) {
-      System.arraycopy(argArray, 0, trimmed, 0, trimmedLen);
-    }
-
-    return trimmed;
+    return NormalizedParameters.trimmedCopy(argArray);
   }
 
 }

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/NOPLogger.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/NOPLogger.java
@@ -25,14 +25,14 @@
 package org.slf4j.helpers;
 
 import org.slf4j.Logger;
-import org.slf4j.helpers.MarkerIgnoringBase;
+import org.slf4j.Marker;
 
 /**
  * A direct NOP (no operation) implementation of {@link Logger}.
  *
  * @author Ceki G&uuml;lc&uuml;
  */
-public class NOPLogger extends MarkerIgnoringBase {
+public class NOPLogger extends NamedLoggerBase implements Logger {
 
   private static final long serialVersionUID = -517220405410904473L;
 
@@ -42,8 +42,9 @@ public class NOPLogger extends MarkerIgnoringBase {
   public static final NOPLogger NOP_LOGGER = new NOPLogger();
 
   /**
-   * There is no point in creating multiple instances of NOPLogger,
-   * except by derived classes, hence the protected  access for the constructor.
+   * There is no point in creating multiple instances of NOPLogger. 
+   * 
+   * The present constructor should be "private" but we are leaving it as "protected" for compatibility.
    */
   protected NOPLogger() {
   }
@@ -51,6 +52,7 @@ public class NOPLogger extends MarkerIgnoringBase {
   /**
    * Always returns the string value "NOP".
    */
+  @Override
   public String getName() {
     return "NOP";
   }
@@ -59,31 +61,37 @@ public class NOPLogger extends MarkerIgnoringBase {
    * Always returns false.
    * @return always false
    */
+  @Override
   final public boolean isTraceEnabled() {
     return false;
   }
 
   /** A NOP implementation. */
+  @Override
   final public void trace(String msg) {
     // NOP
   }
 
   /** A NOP implementation.  */
+  @Override
   final public void trace(String format, Object arg) {
     // NOP
   }
 
   /** A NOP implementation.  */
+  @Override
   public final void trace(String format, Object arg1, Object arg2) {
     // NOP
   }
 
   /** A NOP implementation.  */
+  @Override
   public final void trace(String format, Object... argArray) {
     // NOP
   }
 
   /** A NOP implementation. */
+  @Override
   final public void trace(String msg, Throwable t) {
     // NOP
   }
@@ -107,12 +115,12 @@ public class NOPLogger extends MarkerIgnoringBase {
   }
 
   /** A NOP implementation.  */
-  public final void debug(String format, Object arg1, Object arg2) {
+  final public void debug(String format, Object arg1, Object arg2) {
     // NOP
   }
 
   /** A NOP implementation.  */
-  public final void debug(String format, Object... argArray) {
+  final public void debug(String format, Object... argArray) {
     // NOP
   }
 
@@ -146,7 +154,7 @@ public class NOPLogger extends MarkerIgnoringBase {
   }
 
   /** A NOP implementation.  */
-  public final void info(String format, Object... argArray) {
+  final public void info(String format, Object... argArray) {
     // NOP
   }
 
@@ -179,7 +187,7 @@ public class NOPLogger extends MarkerIgnoringBase {
   }
 
   /** A NOP implementation.  */
-  public final void warn(String format, Object... argArray) {
+  final public void warn(String format, Object... argArray) {
     // NOP
   }
 
@@ -209,7 +217,7 @@ public class NOPLogger extends MarkerIgnoringBase {
   }
 
   /** A NOP implementation.  */
-  public final void error(String format, Object... argArray) {
+  final public void error(String format, Object... argArray) {
     // NOP
   }
 
@@ -217,4 +225,203 @@ public class NOPLogger extends MarkerIgnoringBase {
   final public void error(String msg, Throwable t) {
     // NOP
   }
+
+  // ============================================================
+  // Added NOP methods since MarkerIgnoringBase is now deprecated
+  // ============================================================
+  /**
+   * Always returns false.
+   * @return always false
+   */
+  final public boolean isTraceEnabled(Marker marker) {
+    // NOP
+    return false;
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void trace(Marker marker, String msg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void trace(Marker marker, String format, Object arg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void trace(Marker marker, String format, Object arg1, Object arg2) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void trace(Marker marker, String format, Object... argArray) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void trace(Marker marker, String msg, Throwable t) {
+    // NOP
+  }
+
+  /**
+   * Always returns false.
+   * @return always false
+   */
+  final public boolean isDebugEnabled(Marker marker) {
+    return false;
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void debug(Marker marker, String msg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void debug(Marker marker, String format, Object arg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void debug(Marker marker, String format, Object arg1, Object arg2) {
+    // NOP
+  }
+
+  @Override
+  final public void debug(Marker marker, String format, Object... arguments) {
+    // NOP
+  }
+
+  @Override
+  final public void debug(Marker marker, String msg, Throwable t) {
+    // NOP
+  }
+
+  /**
+   * Always returns false.
+   * @return always false
+   */
+  @Override
+  public boolean isInfoEnabled(Marker marker) {
+    return false;
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void info(Marker marker, String msg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void info(Marker marker, String format, Object arg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void info(Marker marker, String format, Object arg1, Object arg2) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void info(Marker marker, String format, Object... arguments) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void info(Marker marker, String msg, Throwable t) {
+    // NOP
+  }
+
+  /**
+   * Always returns false.
+   * @return always false
+   */
+  @Override
+  final public boolean isWarnEnabled(Marker marker) {
+    return false;
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void warn(Marker marker, String msg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void warn(Marker marker, String format, Object arg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void warn(Marker marker, String format, Object arg1, Object arg2) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void warn(Marker marker, String format, Object... arguments) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void warn(Marker marker, String msg, Throwable t) {
+    // NOP
+  }
+
+  /**
+   * Always returns false.
+   * @return always false
+   */
+  @Override
+  final public boolean isErrorEnabled(Marker marker) {
+    return false;
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void error(Marker marker, String msg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void error(Marker marker, String format, Object arg) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void error(Marker marker, String format, Object arg1, Object arg2) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void error(Marker marker, String format, Object... arguments) {
+    // NOP
+  }
+
+  /** A NOP implementation. */
+  @Override
+  final public void error(Marker marker, String msg, Throwable t) {
+    // NOP
+  }
+  // ===================================================================
+  // End of added NOP methods since MarkerIgnoringBase is now deprecated
+  // ===================================================================
+
 }

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/NOPLoggerFactory.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/NOPLoggerFactory.java
@@ -26,10 +26,9 @@ package org.slf4j.helpers;
 
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.helpers.NOPLogger;
 
 /**
- * NOPLoggerFactory is an trivial implementation of {@link
+ * NOPLoggerFactory is a trivial implementation of {@link
  * ILoggerFactory} which always returns the unique instance of
  * NOPLogger.
  *

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/NormalizedParameters.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/helpers/NormalizedParameters.java
@@ -1,0 +1,116 @@
+package org.slf4j.helpers;
+
+import org.slf4j.event.LoggingEvent;
+
+/**
+ * Holds normalized call parameters.
+ * 
+ * Includes utility methods such as {@link #normalize(String, Object[], Throwable)} to help the normalization of parameters.
+ * 
+ * @author ceki
+ * @since 2.0
+ */
+public class NormalizedParameters {
+
+  final String message;
+  final Object[] arguments;
+  final Throwable throwable;
+
+  public NormalizedParameters(String message, Object[] arguments, Throwable throwable) {
+    this.message = message;
+    this.arguments = arguments;
+    this.throwable = throwable;
+  }
+
+  public NormalizedParameters(String message, Object[] arguments) {
+    this(message, arguments, null);
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public Object[] getArguments() {
+    return arguments;
+  }
+
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  /**
+   * Helper method to determine if an {@link Object} array contains a
+   * {@link Throwable} as last element
+   *
+   * @param argArray The arguments off which we want to know if it contains a
+   *                 {@link Throwable} as last element
+   * @return if the last {@link Object} in argArray is a {@link Throwable} this
+   *         method will return it, otherwise it returns null
+   */
+  public static Throwable getThrowableCandidate(final Object[] argArray) {
+    if (argArray == null || argArray.length == 0) {
+        return null;
+    }
+
+    final Object lastEntry = argArray[argArray.length - 1];
+    if (lastEntry instanceof Throwable) {
+        return (Throwable) lastEntry;
+    }
+
+    return null;
+  }
+
+  /**
+   * Helper method to get all but the last element of an array
+   *
+   * @param argArray The arguments from which we want to remove the last element
+   *
+   * @return a copy of the array without the last element
+   */
+  public static Object[] trimmedCopy(final Object[] argArray) {
+    if (argArray == null || argArray.length == 0) {
+        throw new IllegalStateException("non-sensical empty or null argument array");
+    }
+
+    final int trimmedLen = argArray.length - 1;
+
+    Object[] trimmed = new Object[trimmedLen];
+
+    if (trimmedLen > 0) {
+        System.arraycopy(argArray, 0, trimmed, 0, trimmedLen);
+    }
+
+    return trimmed;
+  }
+
+  /**
+   * This method serves to normalize logging call invocation parameters.
+   * 
+   * More specifically, if a throwable argument is not supplied directly, it
+   * attempts to extract it from the argument array.
+   */
+  public static NormalizedParameters normalize(String msg, Object[] arguments, Throwable t) {
+
+    if (t != null) {
+        return new NormalizedParameters(msg, arguments, t);
+    }
+
+    if (arguments == null || arguments.length == 0) {
+        return new NormalizedParameters(msg, arguments, t);
+    }
+
+    Throwable throwableCandidate = NormalizedParameters.getThrowableCandidate(arguments);
+    if (throwableCandidate != null) {
+        Object[] trimmedArguments = MessageFormatter.trimmedCopy(arguments);
+        return new NormalizedParameters(msg, trimmedArguments, throwableCandidate);
+    } else {
+        return new NormalizedParameters(msg, arguments);
+    }
+
+  }
+
+  public static NormalizedParameters normalize(LoggingEvent event) {
+    return normalize(event.getMessage(), event.getArgumentArray(), event.getThrowable());
+  }
+
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/CallerBoundaryAware.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/CallerBoundaryAware.java
@@ -1,0 +1,25 @@
+package org.slf4j.spi;
+
+import org.slf4j.event.LoggingEvent;
+
+/**
+ * Additional interface to {@link LoggingEventBuilder} and 
+ * {@link org.slf4j.event.LoggingEvent LoggingEvent}.
+ * 
+ * Implementations of {@link LoggingEventBuilder} and  {@link LoggingEvent} may optionally
+ * implement {@link CallerBoundaryAware} in order to support caller info extraction.
+ *
+ * This interface is intended for use by logging backends or logging bridges. 
+ * 
+ * @author Ceki Gulcu
+ *
+ */
+public interface CallerBoundaryAware {
+
+  /**
+   * Add a fqcn (fully qualified class name) to this event, presumed to be the caller boundary.
+   * 
+   * @param fqcn
+   */
+  void setCallerBoundary(String fqcn);
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/DefaultLoggingEventBuilder.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/DefaultLoggingEventBuilder.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2004-2022 QOS.ch
+ * All rights reserved.
+ * <p>
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ * <p>
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ * <p>
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.slf4j.spi;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.DefaultLoggingEvent;
+import org.slf4j.event.KeyValuePair;
+import org.slf4j.event.Level;
+import org.slf4j.event.LoggingEvent;
+
+/**
+ * Default implementation of {@link LoggingEventBuilder}
+ */
+public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBoundaryAware {
+
+
+  // The caller boundary when the log() methods are invoked, is this class itself.
+
+  static String DLEB_FQCN = DefaultLoggingEventBuilder.class.getName();
+
+  protected DefaultLoggingEvent loggingEvent;
+  protected Logger logger;
+
+  public DefaultLoggingEventBuilder(Logger logger, Level level) {
+    this.logger = logger;
+    loggingEvent = new DefaultLoggingEvent(level, logger);
+  }
+
+  /**
+   * Add a marker to the current logging event being built.
+   * <p>
+   * It is possible to add multiple markers to the same logging event.
+   *
+   * @param marker the marker to add
+   */
+  @Override
+  public LoggingEventBuilder addMarker(Marker marker) {
+    loggingEvent.addMarker(marker);
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder setCause(Throwable t) {
+    loggingEvent.setThrowable(t);
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder addArgument(Object p) {
+    this.loggingEvent.addArgument(p);
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder addArgument(Supplier<?> objectSupplier) {
+    this.loggingEvent.addArgument(objectSupplier.get());
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder addKeyValue(String key, Object value) {
+    loggingEvent.addKeyValue(key, value);
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder addKeyValue(String key, Supplier<Object> value) {
+    loggingEvent.addKeyValue(key, value.get());
+    return this;
+  }
+
+  @Override
+  public void setCallerBoundary(String fqcn) {
+    this.loggingEvent.setCallerBoundary(fqcn);
+  }
+
+  @Override
+  public void log() {
+    log(this.loggingEvent);
+  }
+
+  @Override
+  public LoggingEventBuilder setMessage(String message) {
+    this.loggingEvent.setMessage(message);
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder setMessage(Supplier<String> messageSupplier) {
+    this.loggingEvent.setMessage(messageSupplier.get());
+    return this;
+  }
+
+  @Override
+  public void log(String message) {
+    this.loggingEvent.setMessage(message);
+    log(this.loggingEvent);
+  }
+
+  @Override
+  public void log(String message, Object arg) {
+    this.loggingEvent.setMessage(message);
+    this.loggingEvent.addArgument(arg);
+    log(this.loggingEvent);
+  }
+
+  @Override
+  public void log(String message, Object arg0, Object arg1) {
+    this.loggingEvent.setMessage(message);
+    this.loggingEvent.addArgument(arg0);
+    this.loggingEvent.addArgument(arg1);
+    log(this.loggingEvent);
+  }
+
+  @Override
+  public void log(String message, Object... args) {
+    this.loggingEvent.setMessage(message);
+    this.loggingEvent.addArguments(args);
+    
+    log(this.loggingEvent);
+  }
+
+  @Override
+  public void log(Supplier<String> messageSupplier) {
+    if(messageSupplier == null) {
+      log((String) null);
+    } else {
+      log(messageSupplier.get());
+    }
+  }
+
+  protected void log(LoggingEvent aLoggingEvent) {
+    if(aLoggingEvent.getCallerBoundary() == null) {
+      setCallerBoundary(DLEB_FQCN);
+    }
+
+    if(logger instanceof LoggingEventAware) {
+      ((LoggingEventAware) logger).log(aLoggingEvent);
+    } else if(logger instanceof LocationAwareLogger) {
+      logViaLocationAwareLoggerAPI((LocationAwareLogger) logger, aLoggingEvent);
+    } else {
+      logViaPublicSLF4JLoggerAPI(aLoggingEvent);
+    }
+  }
+
+  private void logViaLocationAwareLoggerAPI(LocationAwareLogger locationAwareLogger, LoggingEvent aLoggingEvent) {
+    String msg = aLoggingEvent.getMessage();
+    List<Marker> markerList = aLoggingEvent.getMarkers();
+    String mergedMessage = mergeMarkersAndKeyValuePairsAndMessage(aLoggingEvent);
+    locationAwareLogger.log(null, aLoggingEvent.getCallerBoundary(), aLoggingEvent.getLevel().toInt(),
+                            mergedMessage,
+                            aLoggingEvent.getArgumentArray(), aLoggingEvent.getThrowable());
+  }
+
+  private void logViaPublicSLF4JLoggerAPI(LoggingEvent aLoggingEvent) {
+    Object[] argArray = aLoggingEvent.getArgumentArray();
+    int argLen = argArray == null ? 0 : argArray.length;
+
+    Throwable t = aLoggingEvent.getThrowable();
+    int tLen = t == null ? 0 : 1;
+
+    Object[] combinedArguments = new Object[argLen + tLen];
+
+    if(argArray != null) {
+      System.arraycopy(argArray, 0, combinedArguments, 0, argLen);
+    }
+    if(t != null) {
+      combinedArguments[argLen] = t;
+    }
+
+    String mergedMessage = mergeMarkersAndKeyValuePairsAndMessage(aLoggingEvent);
+
+
+    switch(aLoggingEvent.getLevel()) {
+      case TRACE:
+        logger.trace(mergedMessage, combinedArguments);
+        break;
+      case DEBUG:
+        logger.debug(mergedMessage, combinedArguments);
+        break;
+      case INFO:
+        logger.info(mergedMessage, combinedArguments);
+        break;
+      case WARN:
+        logger.warn(mergedMessage, combinedArguments);
+        break;
+      case ERROR:
+        logger.error(mergedMessage, combinedArguments);
+        break;
+    }
+  }
+
+
+  /**
+   * Prepend markers and key-value pairs to the message.
+   *
+   * @param aLoggingEvent
+   *
+   * @return
+   */
+  private String mergeMarkersAndKeyValuePairsAndMessage(LoggingEvent aLoggingEvent) {
+      StringBuilder sb = mergeMarkers(aLoggingEvent.getMarkers(), null);
+      sb = mergeKeyValuePairs(aLoggingEvent.getKeyValuePairs(), sb);
+      final String mergedMessage = mergeMessage(aLoggingEvent.getMessage(), sb);
+      return mergedMessage;
+  }
+
+  private StringBuilder mergeMarkers(List<Marker> markerList, StringBuilder sb) {
+    if(markerList == null || markerList.isEmpty())
+      return sb;
+
+    if(sb == null)
+      sb = new StringBuilder();
+
+    for(Marker marker : markerList) {
+      sb.append(marker);
+      sb.append(' ');
+    }
+    return sb;
+  }
+
+  private StringBuilder mergeKeyValuePairs(List<KeyValuePair> keyValuePairList, StringBuilder sb) {
+    if(keyValuePairList == null || keyValuePairList.isEmpty())
+      return sb;
+
+    if(sb == null)
+      sb = new StringBuilder();
+
+    for(KeyValuePair kvp : keyValuePairList) {
+      sb.append(kvp.key);
+      sb.append('=');
+      sb.append(kvp.value);
+      sb.append(' ');
+    }
+    return sb;
+  }
+
+  private String mergeMessage(String msg, StringBuilder sb) {
+    if(sb != null) {
+      sb.append(msg);
+      return sb.toString();
+    } else {
+      return msg;
+    }
+  }
+
+
+
+
+
+
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/LocationAwareLogger.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/LocationAwareLogger.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.spi;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ * An <b>optional</b> interface helping integration with logging systems capable of 
+ * extracting location information. This interface is mainly used by SLF4J bridges 
+ * such as jcl-over-slf4j, jul-to-slf4j and log4j-over-slf4j or {@link Logger} wrappers
+ * which need to provide hints so that the underlying logging system can extract
+ * the correct location information (method name, line number).
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @since 1.3
+ */
+public interface LocationAwareLogger extends Logger {
+
+  // these constants should be in EventConstants. However, in order to preserve binary backward compatibility
+  // we keep these constants here. {@link EventConstants} redefines these constants using the values  below.
+  final public int TRACE_INT = 00;
+  final public int DEBUG_INT = 10;
+  final public int INFO_INT = 20;
+  final public int WARN_INT = 30;
+  final public int ERROR_INT = 40;
+
+  /**
+   * Printing method with support for location information. 
+   * 
+   * @param marker The marker to be used for this event, may be null.
+   * 
+   * @param fqcn The fully qualified class name of the <b>logger instance</b>,
+   * typically the logger class, logger bridge or a logger wrapper.
+   * 
+   * @param level One of the level integers defined in this interface
+   * 
+   * @param message The message for the log event
+   * @param t Throwable associated with the log event, may be null.
+   */
+  public void log(Marker marker, String fqcn, int level, String message, Object[] argArray, Throwable t);
+
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/LoggingEventAware.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/LoggingEventAware.java
@@ -1,0 +1,23 @@
+package org.slf4j.spi;
+
+import org.slf4j.event.LoggingEvent;
+
+/**
+ * A logger capable of logging from org.slf4j.event.LoggingEvent implements this interface.
+ *
+ * <p>Please note that when the {@link #log(LoggingEvent)} method assumes that
+ * the event was filtered beforehand and no further filtering needs to occur by the method itself.
+ * <p>
+ *
+ * <p>Implementations of this interface <b>may</b> apply further filtering but they are not
+ * required to do so. In other words, {@link #log(LoggingEvent)} method is free to assume that
+ * the event was filtered beforehand and no further filtering needs to occur in the method itself.</p>
+ *
+ * See also https://jira.qos.ch/browse/SLF4J-575
+ *
+ * @author Ceki Gulcu
+ * @since 2.0.0
+ */
+public interface LoggingEventAware {
+  void log(LoggingEvent event);
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/LoggingEventBuilder.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/LoggingEventBuilder.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2004-2021 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.spi;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Marker;
+
+import org.slf4j.helpers.CheckReturnValue;
+
+/**
+ * This is the main interface in slf4j's fluent API for creating
+ * {@link org.slf4j.event.LoggingEvent logging events}.
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ * @since 2.0.0
+ */
+public interface LoggingEventBuilder {
+
+  /**
+   * Set the cause for the logging event being built.
+   * @param cause a throwable
+   * @return a LoggingEventBuilder, usually <b>this</b>.
+   */
+  @CheckReturnValue
+  LoggingEventBuilder setCause(Throwable cause);
+
+  /**
+   * A {@link Marker marker} to the event being built.
+   *
+   * @param marker a Marker instance to add.
+   * @return a LoggingEventBuilder, usually <b>this</b>.
+   */
+  @CheckReturnValue
+  LoggingEventBuilder addMarker(Marker marker);
+
+  /**
+   * Add an argument to the event being built.
+   *
+   * @param p an Object to add.
+   * @return a LoggingEventBuilder, usually <b>this</b>.
+   */
+  @CheckReturnValue
+  LoggingEventBuilder addArgument(Object p);
+
+  /**
+   * Add an argument supplier to the event being built.
+   *
+   * @param objectSupplier an Object supplier to add.
+   * @return a LoggingEventBuilder, usually <b>this</b>.
+   */
+  @CheckReturnValue
+  LoggingEventBuilder addArgument(Supplier<?> objectSupplier);
+
+
+  /**
+   * Add a {@link org.slf4j.event.KeyValuePair key value pair} to the event being built.
+   *
+   * @param key the key of the key value pair.
+   * @param value the value of the key value pair.
+   * @return a LoggingEventBuilder, usually <b>this</b>.
+   */
+  @CheckReturnValue
+  LoggingEventBuilder addKeyValue(String key, Object value);
+
+  /**
+   * Add a {@link org.slf4j.event.KeyValuePair key value pair} to the event being built.
+   *
+   * @param key the key of the key value pair.
+   * @param valueSupplier a supplier of a value for the key value pair.
+   * @return a LoggingEventBuilder, usually <b>this</b>.
+   */
+  @CheckReturnValue
+  LoggingEventBuilder addKeyValue(String key, Supplier<Object> valueSupplier);
+
+  /**
+   *  Sets the message of the logging event.
+   *
+   *  @since 2.0.0-beta0
+   */
+  @CheckReturnValue
+  LoggingEventBuilder setMessage(String message);
+
+  /**
+   * Sets the message of the event via a message supplier.
+   *
+   * @param messageSupplier supplies a String to be used as the message for the event
+   * @since 2.0.0-beta0
+   */
+  @CheckReturnValue
+  LoggingEventBuilder setMessage(Supplier<String> messageSupplier);
+
+  /**
+   * After the logging event is built, performs actual logging. This method must be called
+   * for logging to occur.
+   *
+   * If the call to {@link #log()}  is omitted, a {@link org.slf4j.event.LoggingEvent LoggingEvent}
+   * will be built but no logging will occur.
+   *
+   * @since 2.0.0-beta0
+   */
+  void log();
+
+  /**
+   * Equivalent to calling {@link #setMessage(String)} followed by {@link #log()};
+   *
+   * @param message the message to log
+   */
+  void log(String message);
+
+  /**
+   * Equivalent to calling {@link #setMessage(String)} followed by {@link #addArgument(Object)}}
+   * and then {@link #log()}
+   *
+   * @param message the message to log
+   * @param arg an argument to be used with the message to log
+   */
+  void log(String message, Object arg);
+
+  /**
+   * Equivalent to calling {@link #setMessage(String)} followed by two calls to
+   * {@link #addArgument(Object)} and then {@link #log()}
+   *
+   * @param message the message to log
+   * @param arg0 first argument to be used with the message to log
+   * @param arg1 second argument to be used with the message to log
+   */
+  void log(String message, Object arg0, Object arg1);
+
+
+  /**
+   * Equivalent to calling {@link #setMessage(String)} followed by zero or more calls to
+   * {@link #addArgument(Object)} (depending on the size of args array) and then {@link #log()}
+   *
+   * @param message the message to log
+   * @param args a list (actually an array) of arguments to be used with the message to log
+   */
+  void log(String message, Object... args);
+
+  /**
+   * Equivalent to calling {@link #setMessage(Supplier)} followed by {@link #log()}
+   *
+   * @param messageSupplier a Supplier returning a message of type String
+   */
+  void log(Supplier<String> messageSupplier);
+
+}

--- a/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/NOPLoggingEventBuilder.java
+++ b/slf4gwt/src/main/java/org/slf4gwt/api/emul/org/slf4j/spi/NOPLoggingEventBuilder.java
@@ -1,0 +1,101 @@
+package org.slf4j.spi;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+
+/**
+ * <p>A no-operation implementation of {@link LoggingEventBuilder}.</p>
+ *
+ * <p>As the name indicates, the method in this class do nothing, except when a return value is expected
+ * in which case a singleton, i.e. the unique instance of this class is returned.
+ * </p
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @since 2.0.0
+ *
+ */
+public class NOPLoggingEventBuilder implements LoggingEventBuilder {
+
+  static final NOPLoggingEventBuilder SINGLETON = new NOPLoggingEventBuilder();
+
+  private NOPLoggingEventBuilder() {
+  }
+
+  /**
+   * <p>Returns the singleton instance of this class.
+   * Used by {@link org.slf4j.Logger#makeLoggingEventBuilder(Level) makeLoggingEventBuilder(Level)}.</p>
+   *
+   * @return the singleton instance of this class
+   */
+  public static LoggingEventBuilder singleton() {
+    return SINGLETON;
+  }
+
+  @Override
+  public LoggingEventBuilder addMarker(Marker marker) {
+    return singleton();
+  }
+
+  @Override
+  public LoggingEventBuilder addArgument(Object p) {
+    return singleton();
+  }
+
+  @Override
+  public LoggingEventBuilder addArgument(Supplier<?> objectSupplier) {
+    return singleton();
+  }
+
+  @Override
+  public LoggingEventBuilder addKeyValue(String key, Object value) {
+    return singleton();
+  }
+
+  @Override
+  public LoggingEventBuilder addKeyValue(String key, Supplier<Object> value) {
+    return singleton();
+  }
+
+  @Override
+  public LoggingEventBuilder setCause(Throwable cause) {
+    return singleton();
+  }
+
+  @Override
+  public void log() {
+  }
+
+  @Override
+  public LoggingEventBuilder setMessage(String message) {
+    return this;
+  }
+
+  @Override
+  public LoggingEventBuilder setMessage(Supplier<String> messageSupplier) {
+    return this;
+  }
+
+  @Override
+  public void log(String message) {
+  }
+
+  @Override
+  public void log(Supplier<String> messageSupplier) {
+  }
+
+  @Override
+  public void log(String message, Object arg) {
+  }
+
+  @Override
+  public void log(String message, Object arg0, Object arg1) {
+  }
+
+  @Override
+  public void log(String message, Object... args) {
+
+  }
+
+}


### PR DESCRIPTION
- Upgraded SLF4J dependency to 2.0.17.
- Applied changes from new version's source code to existing emulated code (while keeping the code style of this repo to minimize the diff, even though it's different from the library's original code style).
- Added additional emulation of classes required for the new fluent logging API.
- The minimum supported version should now be Java 8 and GWT 2.8. (Admittedly I only tested with Java 17 and GWT 2.12)

Closes #6 